### PR TITLE
run prt for dependabot prs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,7 @@ on: # rebuild any PRs and main branch changes
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   build: # make sure build/ci work properly


### PR DESCRIPTION
In order to run workflow for testing dependabot, run them on pull_request_target instead of pull_request