### PR TITLE
update version to latest v16 package of `@types/node`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@discoveryjs/json-ext": "^0.5.7"
       },
       "devDependencies": {
-        "@types/node": "16.11.68",
+        "@types/node": "16.18.26",
         "@typescript-eslint/parser": "^5.59.2",
         "@vercel/ncc": "^0.36.1",
         "eslint": "^8.40.0",
@@ -1563,9 +1563,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "16.11.68",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.68.tgz",
-      "integrity": "sha512-JkRpuVz3xCNCWaeQ5EHLR/6woMbHZz/jZ7Kmc63AkU+1HxnoUugzSWMck7dsR4DvNYX8jp9wTi9K7WvnxOIQZQ==",
+      "version": "16.18.26",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.26.tgz",
+      "integrity": "sha512-pCNBzNQqCXE4A6FWDmrn/o1Qu+qBf8tnorBlNoPNSBQJF+jXzvTKNI/aMiE+hGJbK5sDAD65g7OS/YwSHIEJdw==",
       "dev": true
     },
     "node_modules/@types/prettier": {
@@ -8630,9 +8630,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "16.11.68",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.68.tgz",
-      "integrity": "sha512-JkRpuVz3xCNCWaeQ5EHLR/6woMbHZz/jZ7Kmc63AkU+1HxnoUugzSWMck7dsR4DvNYX8jp9wTi9K7WvnxOIQZQ==",
+      "version": "16.18.26",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.26.tgz",
+      "integrity": "sha512-pCNBzNQqCXE4A6FWDmrn/o1Qu+qBf8tnorBlNoPNSBQJF+jXzvTKNI/aMiE+hGJbK5sDAD65g7OS/YwSHIEJdw==",
       "dev": true
     },
     "@types/prettier": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@discoveryjs/json-ext": "^0.5.7"
   },
   "devDependencies": {
-    "@types/node": "16.11.68",
+    "@types/node": "16.18.26",
     "@typescript-eslint/parser": "^5.59.2",
     "@vercel/ncc": "^0.36.1",
     "eslint": "^8.40.0",


### PR DESCRIPTION
The latest release of Node 16 is [`16.20.0`](https://nodejs.org/dist/v16.20.0/docs/api/).

[`16.11.68`](https://www.npmjs.com/package/@types/node/v/16.11.68) was published 7 months ago.

We should instead use [`16.18.26`](https://www.npmjs.com/package/@types/node/v/16.18.26) which was published 3 days ago.