### PR TITLE
add option to ignore unchanged files in the details section

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,12 +103,13 @@ This action requires the `write` permission for the [`permissions.pull-requests`
 
 ## Options
 
-| name                    | description                                                                                                         | required | type   |
-| ----------------------- | ------------------------------------------------------------------------------------------------------------------- | -------- | ------ |
-| current-stats-json-path | The path to the current stats.json file                                                                             | true     | string |
-| base-stats-json-path    | The path to the base stats.json file                                                                                | true     | string |
-| github-token            | The Github token                                                                                                    | true     | string |
-| title                   | An optional addition to the title, which also helps key comments, useful if running more than 1 copy of this action | false    | string |
+| name                    | description                                                                                                         | required | type    |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------- | -------- | ------- |
+| current-stats-json-path | The path to the current stats.json file                                                                             | true     | string  |
+| base-stats-json-path    | The path to the base stats.json file                                                                                | true     | string  |
+| github-token            | The Github token                                                                                                    | true     | string  |
+| title                   | An optional addition to the title, which also helps key comments, useful if running more than 1 copy of this action | false    | string  |
+| ignore-unchanged        | Omit unchanged files from the detailed breakdown (default: `false`)                                                 | false    | boolean |
 
 ## Example PR Comment
 

--- a/src/print-markdown.ts
+++ b/src/print-markdown.ts
@@ -1,3 +1,5 @@
+import {getBooleanInput} from '@actions/core'
+
 import {formatFileSizeIEC} from './file-sizes'
 import type {AssetDiff, WebpackStatsDiff} from './types'
 
@@ -96,6 +98,12 @@ export function printAssetTablesByGroup(
     'unchanged'
   ] as const
   return statsFields
+    .filter(field => {
+      if (field === 'unchanged' && getBooleanInput('ignore-unchanged')) {
+        return false
+      }
+      return true
+    })
     .map(field => {
       const assets = statsDiff[field]
       if (assets.length === 0) {


### PR DESCRIPTION
As a dinosaur I still read my emails. Although GitHub markdown hides lengthy details in a nice drop down section, a large list of unchanged files makes scrolling through email notifications frustrating. I would argue that for large projects the list of unchanged files is of limited utility.

Edit: ah, I've just noticed: 
  - #459 

(please close this if the other proposal is preferable)