### PR TITLE
Run ci in merge queue

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -17,6 +17,9 @@ on:
   pull_request:
     paths-ignore:
       - '**.md'
+  merge_group:
+    types: [checks_requested]
+    reuse-previous-outcome: true
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on: # rebuild any PRs and main branch changes
   pull_request_target:
     branches:
       - 'dependabot/**'
+  merge_group:
+    types: [checks_requested]
+    reuse-previous-outcome: true
 
 permissions:
   contents: read
@@ -22,6 +25,7 @@ jobs:
           npm run all
   test: # make sure the action works on a clean machine without building
     runs-on: ubuntu-22.04
+    if: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
     steps:
       - uses: actions/checkout@v4
       - uses: ./


### PR DESCRIPTION
I noticed I'm unable to merge a few other PRs because the required workflows are not being kicked off in Merge Queue. This PR adds MQ as a trigger for the CI actions, and adds the `reuse-previous-outcome: true` which allows CI to skip the run if the PR is already up to date with main.